### PR TITLE
Use keyboard events instead of mouse events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
-        "@headlessui/react": "^1.7.3",
+        "@headlessui/react": "^1.7.16",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -2325,9 +2325,12 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.3.tgz",
-      "integrity": "sha512-LGp06SrGv7BMaIQlTs8s2G06moqkI0cb0b8stgq7KZ3xcHdH3qMP+cRyV7qe5x4XEW/IGY48BW4fLesD6NQLng==",
+      "version": "1.7.16",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.16.tgz",
+      "integrity": "sha512-2MphIAZdSUacZBT6EXk8AJkj+EuvaaJbtCyHTJrPsz8inhzCl7qeNPI1uk1AUvCgWylVtdN8cVVmnhUDPxPy3g==",
+      "dependencies": {
+        "client-only": "^0.0.1"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -5799,6 +5802,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -18773,10 +18781,12 @@
       "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw=="
     },
     "@headlessui/react": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.3.tgz",
-      "integrity": "sha512-LGp06SrGv7BMaIQlTs8s2G06moqkI0cb0b8stgq7KZ3xcHdH3qMP+cRyV7qe5x4XEW/IGY48BW4fLesD6NQLng==",
-      "requires": {}
+      "version": "1.7.16",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.16.tgz",
+      "integrity": "sha512-2MphIAZdSUacZBT6EXk8AJkj+EuvaaJbtCyHTJrPsz8inhzCl7qeNPI1uk1AUvCgWylVtdN8cVVmnhUDPxPy3g==",
+      "requires": {
+        "client-only": "^0.0.1"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -21344,6 +21354,11 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
+    },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "cliui": {
       "version": "7.0.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@headlessui/react": "^1.7.3",
+    "@headlessui/react": "^1.7.16",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/ComboBox/ComboBox.js
+++ b/src/ComboBox/ComboBox.js
@@ -13,6 +13,7 @@ const ComboBox = (props) => {
   return (
     <div className="combo-box">
       <Combobox by="id" onChange={_onChange} value={selectedOptions}>
+        <Combobox.Input />
         <Combobox.Button as={Fragment}>
           {() => (
             <button className="combo-box__button" type="button">

--- a/src/ComboBox/ComboBox.test.js
+++ b/src/ComboBox/ComboBox.test.js
@@ -26,8 +26,11 @@ describe(`<ComboBox onChange={() => {}} options={[...]} value="..." />`, () => {
     render(<TestComboBox value="1" />);
 
     // open the dropdown
-    await user.click(screen.getByRole("button"));
-    await user.hover(screen.getAllByRole("option")[3]);
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("[ArrowDown]");
+    await user.keyboard("[ArrowDown]");
+    await user.keyboard("[ArrowDown]");
+    await user.keyboard("[ArrowDown]");
 
     // the active option should have the active class
     expect(screen.getAllByRole("option")[3]).toHaveClass(


### PR DESCRIPTION
This PR uses keyboard events instead of mouse events for tests because they are more reliable than mouse events in JSDom.

- bump Headless UI to latest version
- add missing `<Combobox.Input />`
- use more stable interactions
